### PR TITLE
feat: add main menu keyboard functionality and new menu command

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,5 +1,5 @@
 import { Telegraf } from "telegraf";
-import { sendMessage, registerCommands } from "./helpers/index.js";
+import { sendMessage, registerCommands, getMainMenu } from "./helpers/index.js";
 import { COMMANDS } from "./constants/commands.js";
 import typing from "./middlewares/typing.js";
 import authenticate from "./middlewares/authenticate.js";
@@ -13,7 +13,11 @@ bot.use(typing);
 registerCommands(bot);
 
 bot.start((ctx) => {
-  sendMessage(ctx, "Hello! I'm your Pi-hole bot. How can I help you today?");
+  sendMessage(
+    ctx,
+    "Hello! I'm your Pi-hole bot. How can I help you today?",
+    getMainMenu()
+  );
 });
 
 bot.help((ctx) => {

--- a/src/constants/commands.js
+++ b/src/constants/commands.js
@@ -63,4 +63,10 @@ export const COMMANDS = [
     description: "Show the version of the bot",
     handler: botController.botVersionController,
   },
+  {
+    trigger: ["menu"],
+    description: "Show the menu",
+    handler: botController.menuController,
+    showInKeyboard: false,
+  },
 ];

--- a/src/controllers/__tests__/apiController.test.js
+++ b/src/controllers/__tests__/apiController.test.js
@@ -64,7 +64,7 @@ describe("API Controllers", () => {
       expect(api.get).toHaveBeenCalledWith(API_ENDPOINTS.INFO.MESSAGES);
       expect(sendMessage).toHaveBeenCalledWith(
         mockCtx,
-        "1/1/2021, 12:00:00 AM - Test message"
+        "01/01/2021, 00:00:00 - Test message"
       );
     });
 

--- a/src/controllers/__tests__/botController.test.js
+++ b/src/controllers/__tests__/botController.test.js
@@ -1,5 +1,5 @@
 import botController from "../botController.js";
-import { sendMessage } from "../../helpers/index.js";
+import { sendMessage, getMainMenu } from "../../helpers/index.js";
 import fs from "fs/promises";
 import path from "path";
 import { createMockContext } from "../../__tests__/helpers/testUtils";
@@ -79,6 +79,14 @@ describe("Bot Controller", () => {
         "utf8"
       );
       expect(sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("menuController", () => {
+    it("Should send the menu", async () => {
+      botController.menuController(mockCtx);
+
+      expect(sendMessage).toHaveBeenCalledWith(mockCtx, "Here are the available commands:", getMainMenu());
     });
   });
 });

--- a/src/controllers/botController.js
+++ b/src/controllers/botController.js
@@ -1,4 +1,4 @@
-import { sendMessage } from "../helpers/index.js";
+import { sendMessage, getMainMenu } from "../helpers/index.js";
 import fs from "fs/promises";
 import path from "path";
 
@@ -12,6 +12,11 @@ const botVersionController = async (ctx) => {
   sendMessage(ctx, `The bot version is v${version}`);
 };
 
+const menuController = async (ctx) => {
+  sendMessage(ctx, "Here are the available commands:", getMainMenu());
+};
+
 export default {
   botVersionController,
+  menuController,
 };

--- a/src/helpers/__tests__/keyboard.test.js
+++ b/src/helpers/__tests__/keyboard.test.js
@@ -1,0 +1,29 @@
+import { getMainMenu } from '../keyboard.js';
+import { Markup } from 'telegraf';
+
+jest.mock('telegraf', () => ({
+  Markup: {
+    keyboard: jest.fn().mockReturnValue({ resize: jest.fn() }),
+  },
+}));
+
+jest.mock('../../constants/commands.js', () => ({
+  COMMANDS: [
+    { trigger: 'simple' },
+    { trigger: ['array', 'alias'] },
+    { trigger: 'hidden', showInKeyboard: false },
+    { trigger: 'visible', showInKeyboard: true },
+  ],
+}));
+
+describe('keyboard helper', () => {
+  it('should generate main menu keyboard correctly', () => {
+    getMainMenu();
+
+    expect(Markup.keyboard).toHaveBeenCalledWith(
+      ['/simple', '/array', '/visible'],
+      { columns: expect.any(Number) }
+    );
+  });
+});
+

--- a/src/helpers/__tests__/sendMessage.test.js
+++ b/src/helpers/__tests__/sendMessage.test.js
@@ -9,7 +9,7 @@ describe("sendMessage", () => {
 
     sendMessage(mockCtx, message);
 
-    expect(mockCtx.reply).toHaveBeenCalledWith(message.replaceAll("[✓]", "✅"));
+    expect(mockCtx.reply).toHaveBeenCalledWith(message.replaceAll("[✓]", "✅"), undefined);
   });
 
   it('Should replace all "[✗]" with "❌"', () => {
@@ -17,7 +17,7 @@ describe("sendMessage", () => {
 
     sendMessage(mockCtx, message);
 
-    expect(mockCtx.reply).toHaveBeenCalledWith(message.replaceAll("[✗]", "❌"));
+    expect(mockCtx.reply).toHaveBeenCalledWith(message.replaceAll("[✗]", "❌"), undefined);
   });
 
   it('Should replace all "[i]" with "ℹ️"', () => {
@@ -25,6 +25,6 @@ describe("sendMessage", () => {
 
     sendMessage(mockCtx, message);
 
-    expect(mockCtx.reply).toHaveBeenCalledWith(message.replaceAll("[i]", "ℹ️"));
+    expect(mockCtx.reply).toHaveBeenCalledWith(message.replaceAll("[i]", "ℹ️"), undefined);
   });
 });

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -2,3 +2,4 @@ export { default as sendMessage } from "./sendMessage.js";
 export { default as spawnPiholeCommand } from "./spawnPiholeCommand.js";
 export { default as execCommandWithOutput } from "./execCommandWithOutput.js";
 export * from "./botCommands.js";
+export * from "./keyboard.js";

--- a/src/helpers/keyboard.js
+++ b/src/helpers/keyboard.js
@@ -1,0 +1,19 @@
+import { Markup } from "telegraf";
+import { COMMANDS } from "../constants/commands.js";
+
+export const getMainMenu = () => {
+  return Markup.keyboard(
+    COMMANDS.reduce((acc, command) => {
+      if (command.showInKeyboard === false) {
+        return acc;
+      }
+
+      const trigger = Array.isArray(command.trigger)
+        ? command.trigger[0]
+        : command.trigger;
+      return [...acc, `/${trigger}`];
+    }, []),
+    { columns: 2 }
+  ).resize();
+};
+

--- a/src/helpers/sendMessage.js
+++ b/src/helpers/sendMessage.js
@@ -1,4 +1,4 @@
-export default function sendMessage(ctx, message) {
+export default function sendMessage(ctx, message, extra) {
   const emojiMap = new Map([
     ["[✓]", "✅"],
     ["[✗]", "❌"],
@@ -9,5 +9,5 @@ export default function sendMessage(ctx, message) {
     message = message.replaceAll(key, emoji);
   });
 
-  ctx.reply(message);
+  ctx.reply(message, extra);
 }


### PR DESCRIPTION
- Introduced a new `getMainMenu` function to generate the main menu keyboard.
- Updated the `sendMessage` function to accept an optional parameter for additional options.
- Added a `menuController` to handle the new `/menu` command, sending the main menu to users.
- Updated bot's start message to include the main menu.
- Added tests for the new menu functionality and updated existing tests accordingly.