### PR TITLE
handle null and invalid responses in API controllers

### DIFF
--- a/src/__tests__/api.test.js
+++ b/src/__tests__/api.test.js
@@ -71,13 +71,13 @@ describe("api", () => {
         );
       });
 
-      it("Should return response object when Content-Length is 0", async () => {
+      it("Should return null when Content-Length is 0", async () => {
         const mockResponse = mockApiResponse(null);
         fetch.mockResolvedValueOnce(mockResponse);
 
         const response = await api.post("/", {});
 
-        expect(response).toBe(mockResponse);
+        expect(response).toBeNull();
       });
     });
 
@@ -123,13 +123,13 @@ describe("api", () => {
         );
       });
 
-      it("Should return response object when Content-Length is 0", async () => {
+      it("Should return null when Content-Length is 0", async () => {
         const mockResponse = mockApiResponse(null);
         fetch.mockResolvedValueOnce(mockResponse);
 
         const response = await api.get("/");
 
-        expect(response).toBe(mockResponse);
+        expect(response).toBeNull();
       });
     });
 
@@ -176,13 +176,13 @@ describe("api", () => {
         );
       });
 
-      it("Should return response object when Content-Length is 0", async () => {
+      it("Should return null when Content-Length is 0", async () => {
         const mockResponse = mockApiResponse(null);
         fetch.mockResolvedValueOnce(mockResponse);
 
         const response = await api.delete("/");
 
-        expect(response).toBe(mockResponse);
+        expect(response).toBeNull();
       });
     });
 

--- a/src/api.js
+++ b/src/api.js
@@ -23,11 +23,13 @@ const api = {
     );
   },
   parseResponse(response) {
-    if (response.headers.get("Content-Length") > 0) {
-      return response.json();
+    const contentLength = response.headers.get("Content-Length");
+
+    if (!!contentLength && parseInt(contentLength, 10) === 0) {
+      return Promise.resolve(null);
     }
 
-    return response;
+    return response.json();
   },
   async post(path, data) {
     const response = await fetch(`${this.BASE_URL}${path}`, {

--- a/src/controllers/__tests__/apiController.test.js
+++ b/src/controllers/__tests__/apiController.test.js
@@ -35,6 +35,51 @@ describe("API Controllers", () => {
       );
       expect(sendMessage).toHaveBeenCalledWith(mockCtx, expect.any(String));
     });
+
+    it("Should handle null response", async () => {
+      api.post.mockResolvedValueOnce(null);
+
+      await apiController.authorizeController(mockCtx);
+
+      expect(api.post).toHaveBeenCalledWith(API_ENDPOINTS.AUTH, {
+        password: process.env.PIHOLE_PASSWORD,
+      });
+      expect(api.setHeader).not.toHaveBeenCalled();
+      expect(sendMessage).toHaveBeenCalledWith(
+        mockCtx,
+        "❌ Authorization failed: Invalid response from server"
+      );
+    });
+
+    it("Should handle response without session", async () => {
+      api.post.mockResolvedValueOnce({});
+
+      await apiController.authorizeController(mockCtx);
+
+      expect(api.post).toHaveBeenCalledWith(API_ENDPOINTS.AUTH, {
+        password: process.env.PIHOLE_PASSWORD,
+      });
+      expect(api.setHeader).not.toHaveBeenCalled();
+      expect(sendMessage).toHaveBeenCalledWith(
+        mockCtx,
+        "❌ Authorization failed: Invalid response from server"
+      );
+    });
+
+    it("Should handle response without session.sid", async () => {
+      api.post.mockResolvedValueOnce({ session: {} });
+
+      await apiController.authorizeController(mockCtx);
+
+      expect(api.post).toHaveBeenCalledWith(API_ENDPOINTS.AUTH, {
+        password: process.env.PIHOLE_PASSWORD,
+      });
+      expect(api.setHeader).not.toHaveBeenCalled();
+      expect(sendMessage).toHaveBeenCalledWith(
+        mockCtx,
+        "❌ Authorization failed: Invalid response from server"
+      );
+    });
   });
 
   describe("Logout Controller", () => {
@@ -78,6 +123,30 @@ describe("API Controllers", () => {
       await apiController.messagesController(mockCtx);
 
       expect(sendMessage).toHaveBeenCalledWith(mockCtx, "No messages found");
+    });
+
+    it("Should handle null response", async () => {
+      api.get.mockResolvedValueOnce(null);
+
+      await apiController.messagesController(mockCtx);
+
+      expect(api.get).toHaveBeenCalledWith(API_ENDPOINTS.INFO.MESSAGES);
+      expect(sendMessage).toHaveBeenCalledWith(
+        mockCtx,
+        "❌ Failed to retrieve messages: Invalid response from server"
+      );
+    });
+
+    it("Should handle response without messages property", async () => {
+      api.get.mockResolvedValueOnce({});
+
+      await apiController.messagesController(mockCtx);
+
+      expect(api.get).toHaveBeenCalledWith(API_ENDPOINTS.INFO.MESSAGES);
+      expect(sendMessage).toHaveBeenCalledWith(
+        mockCtx,
+        "❌ Failed to retrieve messages: Invalid response from server"
+      );
     });
   });
 });

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -7,6 +7,11 @@ const authorizeController = async (ctx) => {
     password: process.env.PIHOLE_PASSWORD,
   });
 
+  if (!response || !response.session || !response.session.sid) {
+    sendMessage(ctx, "❌ Authorization failed: Invalid response from server");
+    return;
+  }
+
   api.setHeader("sid", response.session.sid);
 
   sendMessage(ctx, "✅ Authorized successfully");
@@ -20,6 +25,11 @@ const logoutController = async (ctx) => {
 
 const messagesController = async (ctx) => {
   const response = await api.get(API_ENDPOINTS.INFO.MESSAGES);
+
+  if (!response || !response.messages) {
+    sendMessage(ctx, "❌ Failed to retrieve messages: Invalid response from server");
+    return;
+  }
 
   const messages = response.messages;
 


### PR DESCRIPTION
- Updated `parseResponse` method to return null for responses with Content-Length of 0.
- Enhanced error handling in `authorizeController` and `messagesController` to manage null or invalid responses.
- Updated tests to reflect changes in response handling for both authorization and message retrieval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return null for zero-length API responses and harden controllers to handle null/invalid payloads, with tests updated accordingly.
> 
> - **API**
>   - `src/api.js`: Update `parseResponse` to return `null` when `Content-Length` is `0`; otherwise parse JSON.
> - **Controllers**
>   - `src/controllers/apiController.js`:
>     - `authorizeController`: Guard against `null`/missing `session.sid`; send failure message instead of setting header.
>     - `messagesController`: Guard against `null`/missing `messages`; send failure message; keep "No messages found" for empty arrays.
> - **Tests**
>   - `src/__tests__/api.test.js`: Expect `null` for zero-length responses across `post/get/delete`.
>   - `src/controllers/__tests__/apiController.test.js`: Add cases for `null`/invalid responses in `authorizeController` and `messagesController`; assert messaging and header behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da78356ae90cc4c0d360e0ca1139e44fbb2ca332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->